### PR TITLE
Add `FunPtr` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "hs-bindgen-attribute"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "displaydoc",
  "hs-bindgen-types",
@@ -32,10 +38,11 @@ dependencies = [
 
 [[package]]
 name = "hs-bindgen-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d986de5641ea4aa8025589d7243e403961fb0f5572c4dd4764a1bb4a01768c"
+checksum = "aef6c1c28eb3c9a7fd73cb380e2a5114d511ef44b5ffaf5e76559669563abb05"
 dependencies = [
+ "cfg-if",
  "displaydoc",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "hs-bindgen-attribute"
 repository = "https://github.com/yvan-sraka/hs-bindgen-attribute"
 rust-version = "1.64.0"
-version = "0.8.1"
+version = "0.9.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 reflexive = { version = "0.4", optional = true }
 displaydoc = "0.2"
-hs-bindgen-types = "0.8"
+hs-bindgen-types = "0.9"
 lazy_static = { version = "1.4", optional = true }
 quote = "1.0"
 semver = "1.0"

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -1,5 +1,5 @@
 use displaydoc::Display;
-use hs_bindgen_types::HsType;
+use hs_bindgen_types::{ArrowIter, HsType};
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -134,10 +134,8 @@ impl FromStr for Signature {
         }
         .trim_start()
         .to_string();
-        let fn_type = x
-            .next()
-            .ok_or_else(|| Error::MalformedSig(s.to_string()))?
-            .split("->")
+
+        let fn_type = ArrowIter::from(x.next().ok_or_else(|| Error::MalformedSig(s.to_string()))?)
             .map(|ty| {
                 ty.parse::<HsType>()
                     .map_err(|ty| Error::HsType(ty.to_string()))


### PR DESCRIPTION
I've added support for FunPtr for passing haskell functions as arguments to the Rust FFI